### PR TITLE
Fix for missing include breaking CPP backend

### DIFF
--- a/hydra/experimental/detail/Events.inl
+++ b/hydra/experimental/detail/Events.inl
@@ -41,6 +41,7 @@
 #include <stdio.h>
 #include <utility>
 #include <thrust/copy.h>
+#include <thrust/count.h>
 #include <thrust/extrema.h>
 #include <hydra/detail/Config.h>
 #include <hydra/Types.h>


### PR DESCRIPTION
This missing include breaks the CPP backend. Fix provided.