### PR TITLE
Proper guards around omp.h files, taken from Thrust

### DIFF
--- a/hydra/Events.h
+++ b/hydra/Events.h
@@ -39,7 +39,6 @@
 #include <vector>
 #include <string>
 #include <map>
-#include <omp.h>
 #include <iostream>
 #include <ostream>
 #include <algorithm>
@@ -48,7 +47,7 @@
 
 #include <thrust/copy.h>
 
-#include <hydra/detail/Config.h>
+#include <hydra/detail/config.h>
 #include <hydra/Types.h>
 #include <hydra/Containers.h>
 #include <hydra/Vector3R.h>
@@ -56,6 +55,9 @@
 #include <hydra/detail/utility/Utility_Tuple.h>
 #include <hydra/detail/functors/FlagAcceptReject.h>
 
+#if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
+#include <omp.h>
+#endif
 
 namespace hydra {
 

--- a/hydra/detail/Config.h
+++ b/hydra/detail/Config.h
@@ -64,8 +64,8 @@
  #include <thrust/system/cuda/experimental/pinned_allocator.h>
 #endif
 
-#if THRUST_DEVICE_SYSTEM==THRUST_DEVICE_SYSTEM_OMP || THRUST_HOST_SYSTEM==THRUST_HOST_SYSTEM_OMP
- #include <omp.h>
+#if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
+#include <omp.h>
 #endif
 
 #ifndef HYDRA_CERROR_LOG

--- a/hydra/experimental/Events.h
+++ b/hydra/experimental/Events.h
@@ -39,14 +39,15 @@
 #include <vector>
 #include <string>
 #include <map>
-#include <omp.h>
 #include <iostream>
 #include <ostream>
 #include <algorithm>
 #include <time.h>
 #include <stdio.h>
 #include <utility>
+
 #include <thrust/copy.h>
+#include <thrust/detail/config.h>
 
 #include <hydra/detail/Config.h>
 #include <hydra/Types.h>
@@ -56,6 +57,11 @@
 #include <hydra/detail/utility/Utility_Tuple.h>
 #include <hydra/detail/functors/FlagAcceptReject.h>
 #include <hydra/experimental/multivector.h>
+
+
+#if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
+#include <omp.h>
+#endif
 
 namespace hydra {
 

--- a/hydra/experimental/PhaseSpace.h
+++ b/hydra/experimental/PhaseSpace.h
@@ -40,7 +40,6 @@
 #include <vector>
 #include <string>
 #include <map>
-#include <omp.h>
 #include <iostream>
 #include <ostream>
 #include <algorithm>
@@ -64,14 +63,16 @@
 
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/detail/config.h>
 #include <thrust/tuple.h>
 #include <thrust/extrema.h>
 #include <thrust/random.h>
 #include <thrust/distance.h>
 
-
+#if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
+#include <omp.h>
 #include <thrust/system/omp/execution_policy.h>
-
+#endif
 
 
 

--- a/hydra/experimental/detail/Events.inl
+++ b/hydra/experimental/detail/Events.inl
@@ -33,7 +33,6 @@
 #include <vector>
 #include <string>
 #include <map>
-#include <omp.h>
 #include <iostream>
 #include <ostream>
 #include <algorithm>
@@ -50,6 +49,10 @@
 #include <hydra/detail/utility/Utility_Tuple.h>
 #include <hydra/detail/functors/FlagAcceptReject.h>
 #include <hydra/experimental/multivector.h>
+
+#if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
+#include <omp.h>
+#endif
 
 namespace hydra {
 


### PR DESCRIPTION
This fixes the OMP includes being included if compiling without OpenMP, for example TBB or CPP backend on system without OpenMP. The method was taken from the Thrust library's guards on OpenMP code.

Hydra Phase Space is fast on Mac, too! Almost a 4x speedup on a dual core machine with hyper threading and TBB, and 2x faster than Goofy on one core 👍 .