### PR TITLE
Fixed: Bug in swap and extra declaration and definition of operator= in Vector4R

### DIFF
--- a/hydra/Vector4R.h
+++ b/hydra/Vector4R.h
@@ -88,7 +88,6 @@ public:
 			GReal_t pz);
 	__host__      __device__      inline Vector4R& operator*=(GReal_t c);
 	__host__      __device__      inline Vector4R& operator/=(GReal_t c);
-	__host__      __device__      inline Vector4R& operator=(const Vector4R& v2);
 	__host__      __device__      inline Vector4R& operator+=(const Vector4R& v2);
 	__host__      __device__      inline Vector4R& operator-=(const Vector4R& v2);
 	__host__      __device__      inline GReal_t get(GInt_t i) const;

--- a/hydra/detail/Vector3R.inl
+++ b/hydra/detail/Vector3R.inl
@@ -75,7 +75,7 @@ inline void Vector3R::swap(Vector3R& other)
 	if(this==&other) return;
 
 	Vector3R temp(*this);
-	this= other;
+	*this= other;
 	other = temp;
 	return ;
 }

--- a/hydra/detail/Vector4R.inl
+++ b/hydra/detail/Vector4R.inl
@@ -30,18 +30,6 @@
 #define _VECTOR4R_INL_
 
 namespace hydra {
-
-__host__ __device__
-inline Vector4R& Vector4R::operator=(const Vector4R& v2)
-{
-
-	v[0] = v2.get(0);
-	v[1] = v2.get(1);
-	v[2] = v2.get(2);
-	v[3] = v2.get(3);
-
-	return *this;
-}
 __host__ __device__
 inline Vector4R& Vector4R::operator+=(const Vector4R& v2)
 {
@@ -166,18 +154,6 @@ inline Vector4R::Vector4R(Vector4R&& other)
 }
 
 
-
-__host__ __device__
-inline Vector4R& Vector4R::operator=(const Vector4R& other)
-{
-	if(this==&other) return *this;
-	v[0] = other.get(0);
-	v[1] = other.get(1);
-	v[2] = other.get(2);
-	v[3] = other.get(3);
-	 return *this;
-}
-
 __host__ __device__
 inline Vector4R& Vector4R::operator=(Vector4R&& other)
 {
@@ -206,7 +182,7 @@ inline void Vector4R::swap(Vector4R& other)
 	if(this==&other) return;
 
 	Vector4R temp(*this);
-	this= other;
+	*this= other;
 	other = temp;
 	return ;
 }


### PR DESCRIPTION
There was 2 extra definition of operator= in Vector4R and one extra declaration of operator=

And the bug of swap of Vector3R and Vector4R. This bug was causing compilation to fail with the error message 

error: lvalue required as left operand of assignment  this= other;

Signed-off-by: Deepanshu <deepanshu2017@gmail.com>